### PR TITLE
fix(remote-access): Claude Code遠隔利用ガイドをワークフロー形式に刷新

### DIFF
--- a/content/knowledge/remote-access.md
+++ b/content/knowledge/remote-access.md
@@ -1,125 +1,224 @@
 ---
-title: AIへのリモートアクセス方法
-tags: [knowledge, memory, remote-access]
+title: Claude Codeをリモートで使う方法
+tags: [knowledge, memory, remote-access, claude-code]
 ---
-## AIへのリモートアクセス方法：概要
 
-CLIベースのエージェントに対して、スマートフォンや外部環境からリモートで指示・操作を行う主な手法をまとめます。
+## Claude Codeをリモートで使う方法：概要
 
-### 1. API直接利用
+Claude Code（CLIツール）に対して、スマートフォンや外部環境からリモートで操作する主な手法とワークフローをまとめます。
 
-最も直接的な方法です。HTTPリクエストを通じてモデルを呼び出します。
+---
 
-Bash
+## パターン別ワークフロー
 
+### パターン1：外出先のスマホから記事・コードを修正したい
+
+**→ SSH + ヘッドレスモード**
+
+```bash
+# スマホ（Termux等）から手元のサーバーにSSH接続
+ssh user@your-server
+
+# サーバー上でClaude Codeをノンインタラクティブ実行
+claude -p "content/knowledge/remote-access.md の誤字を修正して"
 ```
-curl https://api.example.com/v1/messages \
-  -H "x-api-key: $API_KEY" \
-  -H "version: 2023-06-01" \
+
+**手順**:
+1. スマホに **Termux**（Android）または **iSH / Blink**（iOS）をインストール
+2. `ssh user@your-server` でサーバーへログイン
+3. `claude -p "指示"` で自然言語で指示を出す
+4. 結果を確認・必要なら追加指示
+
+**メリット**: PCなしでもフリック入力だけでドキュメント・コード操作が可能
+
+---
+
+### パターン2：ブラウザだけでClaude Codeを使いたい
+
+**→ Claude Code on the Web（claude.ai/code）**
+
+1. ブラウザで `claude.ai/code` を開く
+2. Anthropicアカウントでログイン（Pro/Max/Team/Enterpriseプラン必須）
+3. Anthropic管理のクラウドVM上でセッションが起動する
+
+**特徴**:
+- ブラウザを閉じてもセッションが継続
+- スマホのブラウザからも監視・操作可能
+- GitHubリポジトリと連携したPR自動修正が可能
+
+---
+
+### パターン3：PCで起動したClaude Codeをスマホから監視・操作したい
+
+**→ Remote Control機能**
+
+```bash
+# PCのClaude Codeでリモートコントロールを有効化
+claude remote-control --verbose
+# → QRコードが表示される
+```
+
+スマホの **Claude公式アプリ** または `claude.ai/code` でQRコードをスキャンするとセッションに接続できます。
+
+**注意事項**:
+- PCのプロセスが起動し続けている必要がある
+- ネットワーク断絶が10分以上続くとセッション終了
+- claude.aiサブスクリプション必須（APIキーでは不可）
+
+---
+
+### パターン4：CI/CDやGitHub Actionsで自動実行したい
+
+**→ GitHub Actions連携**
+
+```yaml
+# .github/workflows/claude-review.yml
+- uses: anthropics/claude-code-action@v1
+  with:
+    anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+    prompt: "このPRのセキュリティ問題をレビューして"
+    claude_args: "--max-turns 5 --model claude-opus-4-7"
+```
+
+**セットアップ**:
+1. Claude Codeで `/install-github-app` を実行
+2. または https://github.com/apps/claude からGitHub Appをインストール
+3. リポジトリのSecretsに `ANTHROPIC_API_KEY` を追加
+
+**用途**: PRレビュー自動化・ドキュメント生成・テスト実行
+
+---
+
+### パターン5：スクリプトや自動化に組み込みたい
+
+**→ ヘッドレスモード（`claude -p`）**
+
+```bash
+# 基本
+claude -p "src/以下のTODOコメントを一覧にして"
+
+# JSON形式で出力（パイプ処理向き）
+claude -p "依存パッケージの脆弱性を調べて" --output-format json
+
+# 許可ツールを明示（CI推奨）
+claude -p "バグを修正して" --allowedTools "Bash,Read,Edit"
+
+# ストリーミング出力
+claude -p "README.mdを更新して" --output-format stream-json --verbose
+```
+
+**cronでの定期実行例**:
+```bash
+# 毎日朝8時にドキュメントの整合性チェック
+0 8 * * * cd ~/note && claude -p "content/以下のリンク切れを確認して報告して" >> ~/logs/claude.log 2>&1
+```
+
+---
+
+### パターン6：APIを直接叩いてアプリやスクリプトに組み込みたい
+
+**→ Anthropic Messages API**
+
+```bash
+curl https://api.anthropic.com/v1/messages \
+  -H "x-api-key: $ANTHROPIC_API_KEY" \
+  -H "anthropic-version: 2023-06-01" \
   -H "content-type: application/json" \
   -d '{
-    "model": "high-end-model",
+    "model": "claude-opus-4-7",
     "max_tokens": 1024,
     "messages": [{"role": "user", "content": "Hello"}]
   }'
 ```
 
-- **用途**: アプリ・スクリプトからの呼び出し
-    
-- **認証**: 環境変数によるAPIキー管理
-    
+**利用可能なモデル（2026年4月現在）**:
 
-### 2. CLI操作（SSH経由）
-
-サーバー上で動作するCLIエージェントに対し、SSH経由で接続して操作します。
-
-Bash
-
-```
-# リモートマシンにSSH接続してCLIを起動
-ssh user@server
-
-# ノンインタラクティブ実行
-ssh user@server "agent-cli --print 'ファイル一覧を出して'"
-```
-
-- **用途**: リモートサーバー上のコードベース操作
-    
-- **前提**: サーバー側にCLIツールがインストール済みであること
-    
-
-### 3. スマートフォンからの記事修正（Terminal Emulator）
-
-スマートフォンからCLIツールを直接叩いて記事を修正する実戦的な方法です。
-
-- **手順**:
-    
-    1. **Terminalアプリ（Termux等）**をスマホにインストール。
-        
-    2. `ssh`でエージェントが動く環境へログイン。
-        
-    3. CLIを起動し、対象のMarkdownファイル（例：`~/note/content/article.md`）への修正指示を出す。
-        
-    4. **「手だけ動かす」**アプローチとして、複雑な編集コマンドを覚えずとも「〜の部分を〜に書き換えて」と自然言語で指示し、即座に反映させる。
-        
-- **メリット**: PCを開けない移動中でも、最小限の入力（フリック入力）でドキュメントのメンテナンスが可能。
-    
-
-### 4. Discord連携（現在の構成）
-
-Discordのメッセージをトリガーに、エージェントが自動応答・処理する構成です。
-
-- **フロー**: `Discordメッセージ` → `MCP経由` → `CLIセッション`
-    
-- **設定**: 設定ファイルのMCPサーバーセクションでプラグインを有効化。
-    
-- **用途**: チャットUIを通じた指示、進捗の通知受け取り。
-    
-
-### 5. 定期実行（Remote Trigger）
-
-スケジュール機能を利用し、エージェントを自動巡回させます。
-
-- **操作**: `/schedule` などのコマンドで登録。
-    
-- **例**: 毎日決まった時間にドキュメントの整合性チェックや要約を実行。
-    
-
-### 6. Web / Desktop App
-
-ブラウザや専用のデスクトップクライアントからのアクセス。
-
-### 7. IDE拡張
-
-VS Code等のリモート開発機能を利用し、エディタ上から直接CLIのコンテキストを利用した修正を行います。
+| モデル | 用途 |
+|---|---|
+| `claude-opus-4-7` | 最高性能・複雑なタスク |
+| `claude-sonnet-4-6` | バランス型（Claude Code自身が使用） |
+| `claude-haiku-4-5-20251001` | 軽量・高速 |
 
 ---
 
-## 比較まとめ
+### パターン7：チャットUIからClaude Codeに指示したい（Discord等）
 
-|**方法**|**リアルタイム性**|**自動化**|**難易度**|**スマホ適性**|
-|---|---|---|---|---|
-|**API直接**|○|◎|低|△|
-|**SSH + CLI**|○|○|中|◎ (Terminal)|
-|**Discord連携**|◎|◎|中|◎ (App)|
-|**Remote Trigger**|△|◎|中|-|
-|**Web/Desktop**|◎|△|低|○|
-|**IDE拡張**|◎|△|低|×|
+**→ MCP（Model Context Protocol）サーバー経由**
+
+公式のDiscord連携は**存在しない**が、MCPサーバーを自作・利用することで実現できます。
+
+**フロー**:
+```
+Discordメッセージ
+    ↓
+Discord Bot（Webhook受信）
+    ↓
+MCPサーバー（ローカル or クラウド）
+    ↓
+Claude Code（ヘッドレスモード）
+    ↓
+結果をDiscordへ返信
+```
+
+**設定（`~/.claude/claude_desktop_config.json`）**:
+```json
+{
+  "mcpServers": {
+    "discord": {
+      "command": "node",
+      "args": ["/path/to/discord-mcp-server.js"]
+    }
+  }
+}
+```
+
+**注意**: サードパーティMCPサーバーはプロンプトインジェクションのリスクがあるため、信頼できるソースのみ使用すること。
+
+---
+
+## IDE拡張でのリモート開発
+
+### VS Code Remote Development
+
+VS Codeのリモート開発機能（SSH/WSL/Dev Container）を利用する場合、リモートホスト側に Claude Code CLI をインストールすれば、IDE上でそのままClaude Codeが使えます。
+
+```bash
+# リモートホストにClaude Codeをインストール
+npm install -g @anthropic-ai/claude-code
+```
+
+### JetBrains IDEs
+
+リモート開発時は**リモートホスト側にもJetBrainsプラグインのインストールが必要**。
+
+---
+
+## パターン比較まとめ
+
+| パターン | 方法 | リアルタイム | 自動化 | スマホ適性 | 難易度 |
+|---|---|---|---|---|---|
+| スマホから直接操作 | SSH + `claude -p` | ○ | ○ | ◎ | 低 |
+| ブラウザのみ | claude.ai/code | ◎ | △ | ◎ | 最低 |
+| PC連動監視 | Remote Control | ◎ | × | ◎ | 低 |
+| CI/CD自動化 | GitHub Actions | △ | ◎ | × | 中 |
+| スクリプト組込み | Headless `-p` | ○ | ◎ | △ | 低 |
+| アプリ開発 | Messages API | ○ | ◎ | △ | 中 |
+| チャットUI | MCP + Discord | ◎ | ◎ | ◎ | 高 |
+
+---
 
 ## 現在の構成図
 
-Plaintext
-
 ```
-[各デバイス（スマホ含む）]
-      ↓
-(Discord / SSH / MCP)
-      ↓
-[CLIエージェント]
-      ↓
+[各デバイス（スマホ・PC・ブラウザ）]
+        ↓
+(SSH / claude.ai/code / Remote Control / MCP)
+        ↓
+[Claude Code CLI]  ←→  [Anthropic API]
+        ↓
 [~/note/content/ (Obsidian記録)]
 ```
 
 ## 参考
-こちらの方が詳しい
-https://qiita.com/nogataka/items/e3a87b16ebb32b3a7281
+- [Claude Code 公式ドキュメント](https://docs.anthropic.com/ja/docs/claude-code)
+- Qiita記事: https://qiita.com/nogataka/items/e3a87b16ebb32b3a7281


### PR DESCRIPTION
- 誤ったAPI URL・ヘッダー・モデル名・コマンドを正確な情報に修正
- 「このパターンはこう」という7つのユースケース別ワークフローに再構成
- Remote Control機能・GitHub Actions・ヘッドレスモードの具体的な手順を追加
- Discord連携について「公式未対応」であることを明記しMCP経由の方法を説明
- 最新モデル一覧（claude-opus-4-7等）を追加

https://claude.ai/code/session_01TBsoz8GwznesGB7CEvj9jw